### PR TITLE
added docker & mongo pipeline without auth on default ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+MONGO_INITDB_ROOT_USERNAME=database_root_username
+MONGO_INITDB_ROOT_PASSWORD=database_root_password
+MONGO_INITDB_DATABASE=database_name
+ME_CONFIG_MONGODB_ADMINUSERNAME=database_root_username
+ME_CONFIG_MONGODB_ADMINPASSWORD=database_root_password

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /venv
 /.vscode
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Set a base image
+FROM python:3.7
+
+# Set the working directory
+WORKDIR /code
+
+# Copy the file from the local host to the filesystem of the container at the working directory.
+COPY waterScrape/requirements.txt .
+
+# Install Scrapy specified in requirements.txt.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the project source code from the local host to the filesystem of the container at the working directory.
+COPY waterScrape/ .
+
+# Run the crawler when the container launches.
+CMD [ "python3", "./runner.py" ]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@
 ```
 scrapy crawl event
 ```
+
+##### Todo:
+- [ ] Secondary parse to get full description
+- [ ] Date parsing to ISO-8601
+- [ ] Allow auth to .env variables for DB pipeline
+- [ ] Finalize incremental update logic
+- [ ] tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+services:
+   # database instance
+   mongo:
+     hostname: mongo
+     container_name: mongo
+     image: mongo:4.2.8
+     restart: always
+     ports:
+       - '27017:27017'
+#     env_file:
+#       - .env
+
+  # admin interface for mongo
+   mongo-express:
+     image: mongo-express:0.54.0
+     hostname: mongo-express
+     container_name: mongo_express
+     restart: always
+     ports:
+       - '8081:8081'
+#     env_file:
+#       - .env
+     depends_on:
+       - mongo
+
+  # Python machine for all of our requirements (just to keep it clean)
+   scraper:
+     build: .
+     hostname: scraper
+     container_name: scraper
+     depends_on:
+       - mongo
+       - mongo-express

--- a/waterScrape/requirements.txt
+++ b/waterScrape/requirements.txt
@@ -1,0 +1,13 @@
+# Scrapers
+Scrapy==2.1.0
+requests==2.23.0
+
+# Parsers
+beautifulsoup4==4.9.1
+
+# Database stuff
+pymongo==3.10.1
+
+# Others
+pytz==2020.1
+pycountry==20.7.3

--- a/waterScrape/runner.py
+++ b/waterScrape/runner.py
@@ -1,0 +1,14 @@
+from scrapy.cmdline import execute
+
+try:
+    execute(
+        [
+            "scrapy",
+            "crawl",
+            "eventSpider",
+            "-o",
+            "waterscraper_results.json",  # todo -- update this
+        ]
+    )
+except SystemExit:
+    pass

--- a/waterScrape/waterScrape/items.py
+++ b/waterScrape/waterScrape/items.py
@@ -8,9 +8,8 @@ import scrapy
 
 class WaterscrapeItem(scrapy.Item):
     # define the fields for your item here like:
-    # name = scrapy.Field()
+    name = scrapy.Field()
     url = scrapy.Field()
-    title = scrapy.Field()
     description = scrapy.Field()
+    place = scrapy.Field()
     date = scrapy.Field()
-    pass

--- a/waterScrape/waterScrape/mongo_provider.py
+++ b/waterScrape/waterScrape/mongo_provider.py
@@ -1,0 +1,18 @@
+import pymongo
+import pdb
+
+
+class MongoProvider(object):
+
+    collection_name = "water"
+
+    def __init__(self, uri, database):
+        self.mongo_uri = uri
+        self.mongo_db = database or "water"
+
+    def get_collection(self):
+        self.client = pymongo.MongoClient(self.mongo_uri)
+        return self.client[self.mongo_db][self.collection_name]
+
+    def close_connection(self):
+        self.client.close()

--- a/waterScrape/waterScrape/pipelines.py
+++ b/waterScrape/waterScrape/pipelines.py
@@ -4,32 +4,27 @@
 # See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 
 
-# useful for handling different item types with a single interface
-from itemadapter import ItemAdapter
-import pymongo
+from .mongo_provider import MongoProvider
+
 
 class MongoPipeline(object):
-
-    collection_name = 'water'
-
-    def __init__(self, mongo_uri, mongo_db):
-        self.mongo_uri = mongo_uri
-        self.mongo_db = mongo_db
+    def __init__(self, settings):
+        self.mongo_provider = MongoProvider(
+            settings.get("MONGO_URI"), settings.get("MONGO_DATABASE")
+        )
 
     @classmethod
     def from_crawler(cls, crawler):
-        return cls(
-            mongo_uri=crawler.settings.get('MONGO_URI'),
-            mongo_db=crawler.settings.get('MONGO_DATABASE', 'waterScrape')
-        )
+        return cls(crawler.settings)
 
     def open_spider(self, spider):
-        self.client = pymongo.MongoClient(self.mongo_uri)
-        self.db = self.client[self.mongo_db]
+        self.collection = self.mongo_provider.get_collection()
 
     def close_spider(self, spider):
-        self.client.close()
+        self.mongo_provider.close_connection()
 
     def process_item(self, item, spider):
-        self.db[self.collection_name].insert_one(dict(item))
+        self.collection.find_one_and_update(
+            {"url": item["url"]}, {"$set": dict(item)}, upsert=True
+        )
         return item

--- a/waterScrape/waterScrape/settings.py
+++ b/waterScrape/waterScrape/settings.py
@@ -7,86 +7,89 @@
 #     https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 #     https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 
-BOT_NAME = 'waterScrape'
+BOT_NAME = "waterScrape"
 
-SPIDER_MODULES = ['waterScrape.spiders']
-NEWSPIDER_MODULE = 'waterScrape.spiders'
+SPIDER_MODULES = ["waterScrape.spiders"]
+NEWSPIDER_MODULE = "waterScrape.spiders"
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-#USER_AGENT = 'waterScrape (+http://www.yourdomain.com)'
+# USER_AGENT = 'waterScrape (+http://www.yourdomain.com)'
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
-#CONCURRENT_REQUESTS = 32
+# CONCURRENT_REQUESTS = 32
 
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-#DOWNLOAD_DELAY = 3
+# DOWNLOAD_DELAY = 3
 # The download delay setting will honor only one of:
-#CONCURRENT_REQUESTS_PER_DOMAIN = 16
-#CONCURRENT_REQUESTS_PER_IP = 16
+# CONCURRENT_REQUESTS_PER_DOMAIN = 16
+# CONCURRENT_REQUESTS_PER_IP = 16
 
 # Disable cookies (enabled by default)
-#COOKIES_ENABLED = False
+# COOKIES_ENABLED = False
 
 # Disable Telnet Console (enabled by default)
-#TELNETCONSOLE_ENABLED = False
+# TELNETCONSOLE_ENABLED = False
 
 # Override the default request headers:
-#DEFAULT_REQUEST_HEADERS = {
+# DEFAULT_REQUEST_HEADERS = {
 #   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
 #   'Accept-Language': 'en',
-#}
+# }
 
 # Enable or disable spider middlewares
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
-#SPIDER_MIDDLEWARES = {
+# SPIDER_MIDDLEWARES = {
 #    'waterScrape.middlewares.WaterscrapeSpiderMiddleware': 543,
-#}
+# }
 
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
-#DOWNLOADER_MIDDLEWARES = {
+# DOWNLOADER_MIDDLEWARES = {
 #    'waterScrape.middlewares.WaterscrapeDownloaderMiddleware': 543,
-#}
+# }
 
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html
-#EXTENSIONS = {
+# EXTENSIONS = {
 #    'scrapy.extensions.telnet.TelnetConsole': None,
-#}
+# }
 
 # Configure item pipelines
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
+# ITEM_PIPELINES = {
 #    'waterScrape.pipelines.WaterscrapePipeline': 300,
-#}
+# }
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
-#AUTOTHROTTLE_ENABLED = True
+# AUTOTHROTTLE_ENABLED = True
 # The initial download delay
-#AUTOTHROTTLE_START_DELAY = 5
+# AUTOTHROTTLE_START_DELAY = 5
 # The maximum download delay to be set in case of high latencies
-#AUTOTHROTTLE_MAX_DELAY = 60
+# AUTOTHROTTLE_MAX_DELAY = 60
 # The average number of requests Scrapy should be sending in parallel to
 # each remote server
-#AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
+# AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 # Enable showing throttling stats for every response received:
-#AUTOTHROTTLE_DEBUG = False
+# AUTOTHROTTLE_DEBUG = False
 
 # Enable and configure HTTP caching (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
-#HTTPCACHE_ENABLED = True
-#HTTPCACHE_EXPIRATION_SECS = 0
-#HTTPCACHE_DIR = 'httpcache'
-#HTTPCACHE_IGNORE_HTTP_CODES = []
-#HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+# HTTPCACHE_ENABLED = True
+# HTTPCACHE_EXPIRATION_SECS = 0
+# HTTPCACHE_DIR = 'httpcache'
+# HTTPCACHE_IGNORE_HTTP_CODES = []
+# HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
 
 ITEM_PIPELINES = {
-   'waterScrape.pipelines.MongoPipeline': 300,
+    "waterScrape.pipelines.MongoPipeline": 300,
 }
+
+MONGO_URI = "mongo:27017"
+MONGO_DATABASE = "water"

--- a/waterScrape/waterScrape/spiders/event_spider.py
+++ b/waterScrape/waterScrape/spiders/event_spider.py
@@ -1,7 +1,8 @@
 import scrapy
 from ..items import WaterscrapeItem
 from ..mongo_provider import MongoProvider
-
+from datetime import datetime
+import calendar
 
 class EventsSpider(scrapy.Spider):
     name = "eventSpider"
@@ -29,16 +30,27 @@ class EventsSpider(scrapy.Spider):
 
     def parse(self, response):
 
+        month_cal = dict((v,k) for v,k in zip(calendar.month_abbr[1:], range(1, 13)))
+        self.logger.info(month_cal)
+
         for post in response.css("div.mec-topsec"):
-            # self.logger.info('Parse function called on %s', response.url)
-            # yield {
-            #'title': post.css('a.mec-color-hover::text').get(),
-            #'title': post.css('div.mec-event-content h3.mec-event-title a.mec-color-hover::text').get()
-            #'date': post.css('span.mec-start-date-label::text').get(),
-            #'description': post.css('div.mec-event-description::text').get()
-            # }
+            self.logger.info('Parse function called on %s', response.url)
+            
+            ISODate_Start = post.css("span.mec-start-date-label::text").get()
+            self.logger.info(ISODate_Start)
+            if ISODate_Start[3] == '-':
+                ISODate_Start = ISODate_Start[:2] + ' ' + str(month_cal[ISODate_Start[8:]])
+                self.logger.info(ISODate_Start)
+            else:
+                ISODate_Start = ISODate_Start[:2] + ' ' + str(month_cal[ISODate_Start[3:6]])
+            #if len(ISODate_Start) >= 7:
+             #   if ISODate_Start[7] == '-':
+            #        ISODate_Start = ISODate_Start[:2] + ' ' + str(month_cal[ISODate_Start[3:6]])
+            
+            ISODate_Start = datetime.strptime(ISODate_Start, '%d %m')
+            ISODate_Start.isoformat()
             item = WaterscrapeItem(
-                date=post.css("span.mec-start-date-label::text").get(),
+                date=ISODate_Start,
                 description=(
                     post.css("div.mec-event-description::text")
                     .get()

--- a/waterScrape/waterScrape/spiders/event_spider.py
+++ b/waterScrape/waterScrape/spiders/event_spider.py
@@ -1,32 +1,56 @@
 import scrapy
-import json
-from waterScrape.items import WaterscrapeItem
+from ..items import WaterscrapeItem
+from ..mongo_provider import MongoProvider
 
-class eventsSpider(scrapy.Spider):
-    name = "event"
 
-    def start_requests(self):
-        urls = [
-            'https://www.internationalrafting.com/racing/events/'
-        ]
-        for url in urls:
-            yield scrapy.Request(url=url, callback=self.parse)
+class EventsSpider(scrapy.Spider):
+    name = "eventSpider"
+    allowed_domains = ["internationalrafting.com"]
+    start_urls = ["https://www.internationalrafting.com/racing/events/"]
+
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        kwargs["mongo_uri"] = crawler.settings.get("MONGO_URI")
+        kwargs["mongo_database"] = crawler.settings.get("MONGO_DATABASE")
+        return super(EventsSpider, cls).from_crawler(crawler, *args, **kwargs)
+
+    def __init__(
+        self, limit_pages=None, mongo_uri=None, mongo_database=None, *args, **kwargs
+    ):
+        super(EventsSpider, self).__init__(*args, **kwargs)
+        if limit_pages is not None:
+            self.limit_pages = int(limit_pages)
+        else:
+            self.limit_pages = 0
+        self.mongo_provider = MongoProvider(mongo_uri, mongo_database)
+        self.collection = self.mongo_provider.get_collection()
+        # last_items = self.collection.find().sort("published_at", -1).limit(1)
+        # self.last_scraped_url = last_items[0]["url"] if last_items.count() else None
 
     def parse(self, response):
-        events = {}
-        
-        for post in response.css('div.mec-topsec'):
-            #self.logger.info('Parse function called on %s', response.url)
-            #yield {
-                #'title': post.css('a.mec-color-hover::text').get(),
-                #'title': post.css('div.mec-event-content h3.mec-event-title a.mec-color-hover::text').get()
-                #'date': post.css('span.mec-start-date-label::text').get(),
-                #'description': post.css('div.mec-event-description::text').get()
-            #}
-            event = {}
-            event.update({"date" : post.css('span.mec-start-date-label::text').get(), "description" : post.css('div.mec-event-description::text').get().encode("ascii", "ignore").decode(), "place" : post.css('div.mec-venue-details address span::text').get(), "url" : post.css("a.mec-color-hover::attr('href')").get()})
-            events[post.css('a.mec-color-hover::text').get().encode("ascii", "ignore").decode()] = event
-            with open('result.json', 'w') as fp:
-                json.dump(events, fp)
-        
-        return events
+
+        for post in response.css("div.mec-topsec"):
+            # self.logger.info('Parse function called on %s', response.url)
+            # yield {
+            #'title': post.css('a.mec-color-hover::text').get(),
+            #'title': post.css('div.mec-event-content h3.mec-event-title a.mec-color-hover::text').get()
+            #'date': post.css('span.mec-start-date-label::text').get(),
+            #'description': post.css('div.mec-event-description::text').get()
+            # }
+            item = WaterscrapeItem(
+                date=post.css("span.mec-start-date-label::text").get(),
+                description=(
+                    post.css("div.mec-event-description::text")
+                    .get()
+                    .encode("ascii", "ignore")
+                    .decode()
+                ),
+                place=post.css("div.mec-venue-details address span::text").get(),
+                url=post.css("a.mec-color-hover::attr('href')").get(),
+                name=post.css("a.mec-color-hover::text")
+                .get()
+                .encode("ascii", "ignore")
+                .decode(),
+            )
+
+            yield item


### PR DESCRIPTION
PR does a few things:
- sets up dockerized versions of mongo, express, and a scraper
- connects and writes to a mongo database
- allows viewing of data on localhost:8081 (mongo-express)
- utilizes items instead of dict directly